### PR TITLE
chnaged task definition to use sha tags

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -57,6 +57,8 @@ module "ecs" {
   user_data_path         = "./ec2-user-data.ps1"
   backend_ecr_url        = module.my_ecr_repo.backend_ecr_repository_url
   backend_ecr_arn        = module.my_ecr_repo.backend_repository_arn
+  backend_repository_name = module.my_ecr_repo.backend_repository_name
   frontend_ecr_url = module.my_ecr_repo.frontend_ecr_repository_url
   frontend_ecr_arn = module.my_ecr_repo.frontend_repository_arn
+  frontend_repository_name = module.my_ecr_repo.frontend_repository_name
 }

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -17,3 +17,13 @@ output "frontend_repository_arn" {
   value       = aws_ecr_repository.graphbuilder_frontend_docker_repo.arn
   description = "The ARN of the frontend ECR repository"
 }
+
+output "backend_repository_name" {
+  value       = aws_ecr_repository.graphbuilder_backend_docker_repo.name
+  description = "The name of the backend ECR repository"
+}
+
+output "frontend_repository_name" {
+  value       = aws_ecr_repository.graphbuilder_frontend_docker_repo.name
+  description = "The name of the frontend ECR repository"
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -54,6 +54,11 @@ variable "backend_ecr_arn" {
   description = "the ecr arn of the backend service"
 }
 
+variable "backend_repository_name" {
+  type        = string
+  description = "the name of the backend ecr repository"
+}
+
 variable "frontend_ecr_url" {
   type = string
   description = "the ecr url of the frontend service"
@@ -62,4 +67,9 @@ variable "frontend_ecr_url" {
 variable "frontend_ecr_arn" {
   type = string
   description = "the ecr arn of the frontend service"
+}
+
+variable "frontend_repository_name" {
+  type        = string
+  description = "the name of the frontend ecr repository"
 }


### PR DESCRIPTION
- changed ecs task definition to use sha sort of tags so that the service will always use the latest image, when we had it as just 'latest' it would re-use the cached image on the ec2